### PR TITLE
Adjust navbar item spacing

### DIFF
--- a/inst/pkgdown/assets/rmd.css
+++ b/inst/pkgdown/assets/rmd.css
@@ -297,10 +297,19 @@ nav[data-toggle='toc'] .nav > .active:focus > a,
 nav[data-toggle='toc'] ul > li > a:hover {
   border-left: 3px solid var(--accent);
   padding-left: 10px;
-  text-indent: -2px;
   letter-spacing: 1pt;
   font-size: 15px;
   text-decoration: none !important;
+}
+
+/* Increase space between list items, descrease within-item spacing */
+nav[data-toggle='toc'] .nav li {
+  margin-top: 0.5em;
+  line-height: 1.5;
+}
+
+nav[data-toggle='toc'] > ul > li:first-child {
+  margin-top: 0;
 }
 
 nav[data-toggle='toc'] .nav > li > a:hover,
@@ -315,7 +324,6 @@ nav[data-toggle='toc'] .nav > li > a:focus {
 nav[data-toggle='toc'] ul > li > a {
   border-left: 3px solid #FFFFFF;
   padding-left: 10px;
-  text-indent: -2px;
   letter-spacing: 1pt;
   font-size: 15px;
   text-decoration: none !important;


### PR DESCRIPTION
A minor CSS adjustment that reduces the line height with the TOC list items so that it's easier to differentiate one item from another. I also made sure that subsequent lines inside a list item are left-aligned with the first line.

| Before | After |
|:--:|:--:|
| ![image](https://user-images.githubusercontent.com/5420529/110498006-efcbfa80-80c4-11eb-803c-514b0911814d.png) | ![image](https://user-images.githubusercontent.com/5420529/110498817-a9c36680-80c5-11eb-9dc9-c8616b6f3627.png) |

