### PR TITLE
Set text-decoration-thickness to from-font in paragraph links 

### DIFF
--- a/inst/pkgdown/assets/rmd.css
+++ b/inst/pkgdown/assets/rmd.css
@@ -102,6 +102,7 @@ a {
 p a {
   text-decoration: underline var(--pg-header) dotted;
   text-decoration-skip-ink: none;
+  text-decoration-thickness: from-font;
 }
 
 


### PR DESCRIPTION
Before this change, link decoration is too thick IMO

<img width="649" alt="Screen Shot 2021-04-02 at 2 26 42 PM" src="https://user-images.githubusercontent.com/1365941/113447494-9c955100-93bf-11eb-980c-85c3b8d812be.png">


After this change, the decoration is more subtle and I think a lot more readable

<img width="667" alt="Screen Shot 2021-04-02 at 2 26 30 PM" src="https://user-images.githubusercontent.com/1365941/113447515-a4ed8c00-93bf-11eb-93b1-ebbe2e57891a.png">
