### PR TITLE
Add direct support in template for new author configuration

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -1,0 +1,5 @@
+footer:
+  right:
+   structure: [authors, pkgdown]
+   components:
+     pkgdown: Site built with <a href="https://pkgdown.r-lib.org">pkgdown</a>.

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,10 +1,9 @@
+{{#footer}}
 <div class="tidyverse">
   <p>{{{yaml.footer}}}{{^yaml.footer}}{{#package}}{{name}}{{/package}} is built for <strong>R Markdown</strong>, an ecosystem of packages for creating computational documents in R. Learn more at <a href="https://rmarkdown.rstudio.com">rmarkdown.rstudio.com</a>.{{/yaml.footer}}</p>
 </div>
 
 <div class="author">
-  <p>
-    Developed by {{#package}}{{{authors}}}{{/package}}.
-    Site built with <a href="https://pkgdown.r-lib.org">pkgdown</a>.
-  </p>
+  <p>{{#right}}{{{.}}}{{/right}}</p>
 </div>
+{{/footer}}


### PR DESCRIPTION
We only modify the small part of our template to support this.
References:
* https://pkgdown.r-lib.org/dev/reference/build_home.html#authors
* https://pkgdown.r-lib.org/dev/reference/build_site.html#yaml-config-footer
* https://pkgdown.r-lib.org/dev/articles/customization.html#sharing-pkgdown-styles-template-packages-1

This is necessary for rticles pkgdown website.

We could modify quillt template deeper to support all the new configuration layer but this is only what we may need for pkgdown rticles website to work.
